### PR TITLE
link against luajit instead of lua5.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 TARGET = jsregexp.so
 SOURCES = jsregexp.c cutils.c libregexp.c libunicode.c
 OBJECTS = $(SOURCES:%.c=%.o)
-INCLUDE = -I/usr/include/lua5.1
-LIBOPTS = -shared -llua5.1
+INCLUDE = -I/usr/include/luajit-2.1/
+LIBOPTS = -shared -lluajit-5.1
 FLAGS = -fpic -flto
 CC = gcc
 


### PR DESCRIPTION
Hey, me again :D

I think jsregexp should link against luajit instead of lua, afaict only the latter is a runtime-dependency of neovim (At least the [arch-package](https://archlinux.org/packages/community/x86_64/neovim/) for neovim indicates as much) and therefore more likely to be installed when this is installed through... packer, probably.

This works on arch with `luajit` and Ubuntu with `libluajit-5.1-dev`.

I don't have any experience writing C for lua, if there is a reason jsregexp links agains lua5.1, disregard this :sweat_smile: