### PR TITLE
Support multiple lua versions + CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: test
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: true
+      matrix:
+        luaVersion:
+          [
+            "5.1.5",
+            "5.2.4",
+            "5.3.5",
+            "5.4.1",
+            "5.1",
+            "5.4",
+            "luajit-2.0.5",
+            "luajit-2.1.0-beta3",
+          ]
+        machineTag: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.machineTag }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: leafo/gh-actions-lua@v8.0.0
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
+      - uses: leafo/gh-actions-luarocks@v4.0.0
+        with:
+          luarocksVersion: "3.8.0"
+      - name: build
+        run: |
+          make build
+      - name: test
+        run: lua test.lua

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,8 @@ jobs:
             "luajit-2.0.5",
             "luajit-2.1.0-beta3",
           ]
-        machineTag: ["ubuntu-latest", "macos-latest", "windows-latest"]
+          # TODO: add windows-latest once: https://github.com/leafo/gh-actions-lua/pull/23 is fully released
+        machineTag: ["ubuntu-latest", "macos-latest"]
     runs-on: ${{ matrix.machineTag }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,6 @@ jobs:
           luarocksVersion: "3.8.0"
       - name: build
         run: |
-          make build
+          luarocks make
       - name: test
         run: lua test.lua

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,25 +13,23 @@ jobs:
       matrix:
         luaVersion:
           [
-            "5.1.5",
-            "5.2.4",
-            "5.3.5",
-            "5.4.1",
             "5.1",
+            "5.2",
+            "5.3",
             "5.4",
             "luajit-2.0.5",
             "luajit-2.1.0-beta3",
           ]
-        machineTag: ["ubuntu-latest", "macos-latest"]
+        machineTag: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.machineTag }}
     steps:
       - uses: actions/checkout@v2
-      - uses: leafo/gh-actions-lua@v8.0.0
+      - uses: leafo/gh-actions-lua@v9
         with:
           luaVersion: ${{ matrix.luaVersion }}
-      - uses: leafo/gh-actions-luarocks@v4.0.0
+      - uses: leafo/gh-actions-luarocks@v4
         with:
-          luarocksVersion: "3.8.0"
+          luarocksVersion: "3.9.1"
       - name: build
         run: |
           luarocks make

--- a/jsregexp-0.0.3-1.rockspec
+++ b/jsregexp-0.0.3-1.rockspec
@@ -14,7 +14,7 @@ WIP: This library offers a single function to use javascript regular expressions
 	license = "MIT"
 }
 dependencies = {
-	"lua == 5.1",
+	"lua >= 5.1",
 }
 build = {
 	type = "builtin",

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -152,7 +152,7 @@ int luaopen_jsregexp(lua_State *lstate)
 #if LUA_VERSION_NUM >= 502
     luaL_setfuncs(lstate, jsregexp_meta, 0);
 #else
-    luaL_register(L, NULL, jsregexp_meta);
+    luaL_register(lstate, NULL, jsregexp_meta);
 #endif
   lua_pop(lstate, 1);
   return 1;

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -17,7 +17,9 @@
 #define lua_tbl_len(L, arg) (lua_objlen(L, arg))
 #endif
 
-
+#if LUA_VERSION_NUM < 503
+#define lua_pushinteger(L, n) lua_pushinteger(L, n)
+#endif
 
 struct regex {
   uint8_t *bc;
@@ -55,10 +57,10 @@ static int regex_closure(lua_State *lstate)
 
     lua_newtable(lstate);
 
-    lua_pushnumber(lstate, 1 + capture[0] - input);
+    lua_pushinteger(lstate, 1 + capture[0] - input);
     lua_setfield(lstate, -2, "begin_ind");
 
-    lua_pushnumber(lstate, capture[1] - input);
+    lua_pushinteger(lstate, capture[1] - input);
     lua_setfield(lstate, -2, "end_ind");
 
     lua_newtable(lstate);


### PR DESCRIPTION
Support jsregexp with multiple lua versions.

Also add CI check that runs the `test.lua` across matrix of OS and lua versions