### PR TITLE
Makefile: allow overriding some vars via env.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 # This file is meant for testing locally, it is not used by luarocks.
 
-TARGET = jsregexp.so
-SOURCES = jsregexp.c cutils.c libregexp.c libunicode.c
-OBJECTS = $(SOURCES:%.c=%.o)
-INCLUDE_DIR = -I/usr/include/lua5.1
-LDLIBS = -llua5.1
-LDFLAGS = -shared
-CFLAGS = $(INCLUDE_DIR) -O2 -fPIC
-CC = gcc
+TARGET ?= jsregexp.so
+SOURCES ?= jsregexp.c cutils.c libregexp.c libunicode.c
+OBJECTS ?= $(SOURCES:%.c=%.o)
+INCLUDE_DIR ?= -I/usr/include/lua5.1
+LDLIBS ?= -llua5.1
+LDFLAGS ?= -shared
+CFLAGS ?= $(INCLUDE_DIR) -O2 -fPIC
+CC ?= gcc
 
 .PHONY: all clean
 


### PR DESCRIPTION
Hey, me again :D

Since luarocks are a bit meh to use in nvim right now, I'd like to add the option of installing jsregexp via some command to luasnip.

My current plan for doing this is
1. find lua-version used via nvim (`nvim -v` provides some info here) and
2. modify INCLUDE_DIR and LDLIBS based on that.

For that, these vars would have to be overridable, which is what this PR implements.

Alternatively, the check for the available lua-version could live in this repo, which would be nicer IMO, but with that there's a weird, slightly out-of-place dependency on `nvim`, not sure if you want that (maybe a separate `with_nvim`/`for_nvim`-target with the check?)

WDYT? Would you be up for maintaing the cross-platform install (only linux for now I think, I don't yet know how to link agains lua on windows) or do you dislike that approach?