### PR TITLE
Implement `reg:exec(str)` and `reg:test(str)`

### DIFF
--- a/jsregexp.c
+++ b/jsregexp.c
@@ -71,7 +71,7 @@ static inline uint16_t *utf8_to_utf16(
     uint32_t *utf16_len,
     uint32_t **indices)
 {
-  *indices = calloc((n+1), sizeof *indices);
+  *indices = calloc((n+1), sizeof **indices);
   uint16_t *str = malloc((n+1) * sizeof *str);
   uint16_t *q = str;
 

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -376,7 +376,7 @@ static int regexp_test(lua_State *lstate)
   uint32_t last_index = global ? r->last_index : 0;
 
   const bool ret = lre_exec(capture, r->bc, (uint8_t *) input, last_index,
-      input_len, 0, NULL) == 1;
+      input_len, 0, NULL);
 
   if (global) {
     if (ret != 1) {

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -403,7 +403,7 @@ static int regexp_index(lua_State *lstate)
   if (lua_isnil(lstate, -1)) {
     const char *key = lua_tostring(lstate, 2);
     if (streq(key, "last_index")) {
-      lua_pushnumber(lstate, r->last_index);
+      lua_pushnumber(lstate, r->last_index + 1);
     } else if (streq(key, "global")) {
       lua_pushboolean(lstate, lre_get_flags(r->bc) & LRE_FLAG_GLOBAL);
     } else {
@@ -422,8 +422,8 @@ static int regexp_newindex(lua_State *lstate)
   const char *key = lua_tostring(lstate, 2);
   if (streq(key, "last_index")) {
     const int ind = luaL_checknumber(lstate, 3);
-    luaL_argcheck(lstate, ind >= 0, 3, "last_index must be non-negative");
-    r->last_index = ind;
+    luaL_argcheck(lstate, ind >= 1, 3, "last_index must be positive");
+    r->last_index = ind - 1;
   } else {
       luaL_argerror(lstate, 2, "unrecognized key");
   }

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -305,6 +305,10 @@ static int regexp_exec(lua_State *lstate)
   const int ret = lre_exec(capture, r->bc, (uint8_t *) input, last_index,
       input_len, 0, NULL);
 
+  if (ret < 0) {
+    luaL_error(lstate, "out of memory in regexp execution");
+  }
+
   if (global) {
     if (ret != 1) {
       r->last_index = 0;
@@ -375,8 +379,12 @@ static int regexp_test(lua_State *lstate)
   const int global = lre_get_flags(r->bc) & LRE_FLAG_GLOBAL;
   uint32_t last_index = global ? r->last_index : 0;
 
-  const bool ret = lre_exec(capture, r->bc, (uint8_t *) input, last_index,
+  const int ret = lre_exec(capture, r->bc, (uint8_t *) input, last_index,
       input_len, 0, NULL);
+
+  if (ret < 0) {
+    luaL_error(lstate, "out of memory in regexp execution");
+  }
 
   if (global) {
     if (ret != 1) {
@@ -425,7 +433,7 @@ static int regexp_newindex(lua_State *lstate)
     luaL_argcheck(lstate, ind >= 1, 3, "last_index must be positive");
     r->last_index = ind - 1;
   } else {
-      luaL_argerror(lstate, 2, "unrecognized key");
+    luaL_argerror(lstate, 2, "unrecognized key");
   }
 
   return 0;

--- a/test.lua
+++ b/test.lua
@@ -5,7 +5,7 @@ local fails = 0
 local successes = 0
 
 -- TODO: print more info case on fail
-local function test(str, regex, flags, want)
+local function test_call(str, regex, flags, want)
 	local function fail(...)
 		print(str, regex, flags, want)
 		print(...)
@@ -154,76 +154,76 @@ local function test_test(str, regex, flags, want)
 end
 
 
-test("dummy", "(.*", "", nil)
-test("dummy", "[", "", nil)
+test_call("dummy", "(.*", "", nil)
+test_call("dummy", "[", "", nil)
 
-test("dummy", ".", "", {{"d"}})
-test("du", ".", "g", {{"d"}, {"u"}})
+test_call("dummy", ".", "", {{"d"}})
+test_call("du", ".", "g", {{"d"}, {"u"}})
 
-test("dummy", "c", "", {})
-test("dummy", "c", "g", {})
-test("dummy", "d", "", {{"d"}})
-test("dummy", "m", "", {{"m"}})
-test("dummy", "m", "g", {{"m"}, {"m"}})
+test_call("dummy", "c", "", {})
+test_call("dummy", "c", "g", {})
+test_call("dummy", "d", "", {{"d"}})
+test_call("dummy", "m", "", {{"m"}})
+test_call("dummy", "m", "g", {{"m"}, {"m"}})
 
-test("dummy", "(dummy)", "", {{"dummy", groups = {"dummy"}}})
-test("The quick brown fox jumps over the lazy dog", "\\w+", "", {{"The"}})
-test("The quick brown fox jumps over the lazy dog", "\\w+", "g", {{"The"}, {"quick"}, {"brown"}, {"fox"}, {"jumps"}, {"over"}, {"the"}, {"lazy"}, {"dog"}})
-test("The quick brown fox jumps over the lazy dog", "[aeiou]{2,}", "g", {{"ui"}})
+test_call("dummy", "(dummy)", "", {{"dummy", groups = {"dummy"}}})
+test_call("The quick brown fox jumps over the lazy dog", "\\w+", "", {{"The"}})
+test_call("The quick brown fox jumps over the lazy dog", "\\w+", "g", {{"The"}, {"quick"}, {"brown"}, {"fox"}, {"jumps"}, {"over"}, {"the"}, {"lazy"}, {"dog"}})
+test_call("The quick brown fox jumps over the lazy dog", "[aeiou]{2,}", "g", {{"ui"}})
 
-test("äöü", ".", "g", {{"ä"}, {"ö"}, {"ü"}})
-test("äöü", ".", "", {{"ä"}})
-test("ÄÖÜ", ".", "", {{"Ä"}})
-test("äöü", "[äöü]", "g", {{"ä"}, {"ö"}, {"ü"}})
-test("äöü", "[äöü]*", "g", {{"äöü"}, {""}})
-test("äÄ", "ä", "gi", {{"ä"}, {"Ä"}})
-test("öäü.haha", "([^.]*)\\.(.*)", "", {{"öäü.haha", groups={"öäü", "haha"}}})
+test_call("äöü", ".", "g", {{"ä"}, {"ö"}, {"ü"}})
+test_call("äöü", ".", "", {{"ä"}})
+test_call("ÄÖÜ", ".", "", {{"Ä"}})
+test_call("äöü", "[äöü]", "g", {{"ä"}, {"ö"}, {"ü"}})
+test_call("äöü", "[äöü]*", "g", {{"äöü"}, {""}})
+test_call("äÄ", "ä", "gi", {{"ä"}, {"Ä"}})
+test_call("öäü.haha", "([^.]*)\\.(.*)", "", {{"öäü.haha", groups={"öäü", "haha"}}})
 
-test("𝄞", "𝄞(", "", nil)
-test("𝄞", "𝄞", "", {{"𝄞"}})
+test_call("𝄞", "𝄞(", "", nil)
+test_call("𝄞", "𝄞", "", {{"𝄞"}})
 -- these empty matches are expected and consistent with vscode
-test("öö öö", "ö*", "g", {{"öö"}, {""}, {"öö"}, {""}})
-test("𝄞𝄞 𝄞𝄞", "[^ ]*", "g", {{"𝄞𝄞"}, {""}, {"𝄞𝄞"}, {""}})
-test("𝄞𝄞", "𝄞*", "", {{"𝄞𝄞"}})
+test_call("öö öö", "ö*", "g", {{"öö"}, {""}, {"öö"}, {""}})
+test_call("𝄞𝄞 𝄞𝄞", "[^ ]*", "g", {{"𝄞𝄞"}, {""}, {"𝄞𝄞"}, {""}})
+test_call("𝄞𝄞", "𝄞*", "", {{"𝄞𝄞"}})
 -- doesn't work in vscode, matches only a single 𝄞 each time:
-test("𝄞𝄞𐐷𝄞𝄞", "𝄞*", "g", {{"𝄞𝄞"}, {""}, {"𝄞𝄞"}, {""}})
+test_call("𝄞𝄞𐐷𝄞𝄞", "𝄞*", "g", {{"𝄞𝄞"}, {""}, {"𝄞𝄞"}, {""}})
 -- vscode actually splits the center unicode character and produces an extra empty match. we don't.
-test("öö𐐷öö", "ö*", "g", {{"öö"}, {""}, {"öö"}, {""}})
-test("a", "𝄞|a", "g", {{"a"}}) -- utf16 regex, ascii input
+test_call("öö𐐷öö", "ö*", "g", {{"öö"}, {""}, {"öö"}, {""}})
+test_call("a", "𝄞|a", "g", {{"a"}}) -- utf16 regex, ascii input
 
-test("κόσμε", "(κόσμε)", "", {{"κόσμε", groups={"κόσμε"}}})
+test_call("κόσμε", "(κόσμε)", "", {{"κόσμε", groups={"κόσμε"}}})
 
-test("jordbær fløde på", "(jordbær fløde på)", "", {{"jordbær fløde på", groups={"jordbær fløde på"}}})
+test_call("jordbær fløde på", "(jordbær fløde på)", "", {{"jordbær fløde på", groups={"jordbær fløde på"}}})
 
-test("Heizölrückstoßabdämpfung", "(Heizölrückstoßabdämpfung)", "", {{"Heizölrückstoßabdämpfung", groups={"Heizölrückstoßabdämpfung"}}})
+test_call("Heizölrückstoßabdämpfung", "(Heizölrückstoßabdämpfung)", "", {{"Heizölrückstoßabdämpfung", groups={"Heizölrückstoßabdämpfung"}}})
 
-test("Fête l'haï volapük", "(Fête l'haï volapük)", "", {{"Fête l'haï volapük", groups={"Fête l'haï volapük"}}})
+test_call("Fête l'haï volapük", "(Fête l'haï volapük)", "", {{"Fête l'haï volapük", groups={"Fête l'haï volapük"}}})
 
-test("Árvíztűrő tükörfúrógép", "(Árvíztűrő tükörfúrógép)", "", {{"Árvíztűrő tükörfúrógép", groups={"Árvíztűrő tükörfúrógép"}}})
+test_call("Árvíztűrő tükörfúrógép", "(Árvíztűrő tükörfúrógép)", "", {{"Árvíztűrő tükörfúrógép", groups={"Árvíztűrő tükörfúrógép"}}})
 
-test("いろはにほへとちりぬるを", "(いろはにほへとちりぬるを)", "", {{"いろはにほへとちりぬるを", groups={"いろはにほへとちりぬるを"}}})
+test_call("いろはにほへとちりぬるを", "(いろはにほへとちりぬるを)", "", {{"いろはにほへとちりぬるを", groups={"いろはにほへとちりぬるを"}}})
 
-test("Съешь же ещё этих мягких французских булок да выпей чаю", "(Съешь же ещё этих мягких французских булок да выпей чаю)", "", {{"Съешь же ещё этих мягких французских булок да выпей чаю", groups={"Съешь же ещё этих мягких французских булок да выпей чаю"}}})
+test_call("Съешь же ещё этих мягких французских булок да выпей чаю", "(Съешь же ещё этих мягких французских булок да выпей чаю)", "", {{"Съешь же ещё этих мягких французских булок да выпей чаю", groups={"Съешь же ещё этих мягких французских булок да выпей чаю"}}})
 
 -- no idea how thai works
 -- test("จงฝ่าฟันพัฒนาวิชาการ", "(จงฝ่าฟันพัฒนาวิชาการ)", "", {{"จงฝ่าฟันพัฒนาวิชาการ", groups="จงฝ่าฟันพัฒนาวิชาการ"}})
 
 -- 0xfd (together with other wird chars) crashes lre_compile if not caught
 -- (luajit at least..)
-test("dummy", string.char(0xfd, 166, 178, 165, 138, 183), "", nil)
+test_call("dummy", string.char(0xfd, 166, 178, 165, 138, 183), "", nil)
 
 
 -- named groups:
-test("The quick brown fox jumps over the lazy dog", "(?<first_word>\\w+) (\\w+) (?<third_word>\\w+)", "n",
+test_call("The quick brown fox jumps over the lazy dog", "(?<first_word>\\w+) (\\w+) (?<third_word>\\w+)", "n",
 {{"The quick brown", groups={"The", "quick", "brown"}, named_groups={first_word="The", third_word="brown"}}}
 )
-test("The qüick bröwn föx jümps över the lazy dög", "(?<first_word>[^ ]+) ([^ ]+) (?<third_word>[^ ]+)", "n",
+test_call("The qüick bröwn föx jümps över the lazy dög", "(?<first_word>[^ ]+) ([^ ]+) (?<third_word>[^ ]+)", "n",
 {{"The qüick bröwn", groups={"The", "qüick", "bröwn"}, named_groups={first_word="The", third_word="bröwn"}}}
 )
-test("The quick bröwn föx", "(?<first_wörd>[^ ]+) ([^ ]+) (?<third_wörd>[^ ]+)", "n",
+test_call("The quick bröwn föx", "(?<first_wörd>[^ ]+) ([^ ]+) (?<third_wörd>[^ ]+)", "n",
 {{"The quick bröwn", groups={"The", "quick", "bröwn"}, named_groups={["first_wörd"]="The", ["third_wörd"]="bröwn"}}}
 )
-test("𝄞𝄞 𐐷", "(?<word>[^ ]+)", "ng", {{"𝄞𝄞", groups={"𝄞𝄞"}, named_groups={word="𝄞𝄞"}}, {"𐐷", groups={"𐐷"}, named_groups={word="𐐷"}}})
+test_call("𝄞𝄞 𐐷", "(?<word>[^ ]+)", "ng", {{"𝄞𝄞", groups={"𝄞𝄞"}, named_groups={word="𝄞𝄞"}}, {"𐐷", groups={"𐐷"}, named_groups={word="𐐷"}}})
 
 test_exec("The quick brown", "\\w+", "g", {{[0]="The"}, {[0]="quick"}, {[0]="brown"}})
 test_exec("The quick brown fox", "(\\w+) (\\w+)", "g", {{[0]="The quick", "The", "quick"}, {[0]="brown fox", "brown", "fox"}})


### PR DESCRIPTION
@nathanrpage97 I would like your opinion on how we can handle unicode strings. As in JS, one can build `match`, `findAll` etc. by repeatedly calling `reg:exec` on the input and getting the next match each time. The starting index is stored inside the `RegExp` object. Converting the string to UTF16 on each call to `exec` would clearly be bad. My idea is to cache the converted string and save a reference to the input string (in the registry?) to check if we are still working on the same input.