### PR TITLE
add jsstring userdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .ccls
 .ccls-cache
 *.lua
-!lre.lua
+!jsregexp.lua
 tags
 tags.lock
 tags.temp

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .ccls
 .ccls-cache
 *.lua
+!lre.lua
 tags
 tags.lock
 tags.temp

--- a/jsregexp-0.0.5-1.rockspec
+++ b/jsregexp-0.0.5-1.rockspec
@@ -1,29 +1,25 @@
 package = "jsregexp"
 version = "0.0.5-1"
 source = {
-	url = "git://github.com/kmarius/jsregexp.git",
-	branch = "master",
-	tag = "v0.0.5",
+    url = "git://github.com/kmarius/jsregexp.git",
+    branch = "master",
+    tag = "v0.0.5"
 }
 description = {
-	summary = "javascript (ECMA19) regular expressions for lua",
-	detailed = [[
+    summary = "javascript (ECMA19) regular expressions for lua",
+    detailed = [[
 WIP: This library offers a single function to use javascript regular expressions in lua. It makes use of libregexp from https://bellard.org/quickjs/.
 	]],
-	homepage = "https://github.com/kmarius/jsregexp",
-	license = "MIT"
+    homepage = "https://github.com/kmarius/jsregexp",
+    license = "MIT"
 }
-dependencies = {
-	"lua >= 5.1",
-}
+dependencies = {"lua >= 5.1"}
 build = {
-	type = "builtin",
-	modules = {
-		jsregexp = {
-			"cutils.c",
-			"jsregexp.c",
-			"libregexp.c",
-			"libunicode.c",
-		}
-	}
+    type = "builtin",
+    modules = {
+        ["jsregexp.core"] = {
+            "cutils.c", "jsregexp.c", "libregexp.c", "libunicode.c"
+        },
+        jsregexp = "jsregexp.lua"
+    }
 }

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -511,7 +511,6 @@ static int regexp_newindex(lua_State *lstate)
   return 0;
 }
 
-
 static struct luaL_Reg jsregexp_meta[] = {
   {"exec", regexp_exec},
   {"test", regexp_test},
@@ -599,7 +598,7 @@ static const struct luaL_Reg jsregexp_lib[] = {
   {NULL, NULL}
 };
 
-int luaopen_jsregexp(lua_State *lstate)
+int luaopen_jsregexp_core(lua_State *lstate)
 {
   luaL_newmetatable(lstate, JSREGEXP_MATCH_MT);
   lua_pushcfunction(lstate, match_tostring);
@@ -614,6 +613,8 @@ int luaopen_jsregexp(lua_State *lstate)
   lua_set_functions(lstate, jsstring_meta);
   
   new_lib(lstate, jsregexp_lib);
+  luaL_getmetatable(lstate, JSREGEXP_MT);
+  lua_setfield(lstate, -2, "mt");
 
   return 1;
 }

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -544,6 +544,11 @@ static int jsregexp_compile(lua_State *lstate)
     luaL_argerror(lstate, 1, "malformed unicode");
   }
 
+  if (utf8_contains_non_bmp(regexp)) {
+    // bmp range works fine without utf16 flag
+    re_flags |= LRE_FLAG_UTF16;
+  }
+
   if (!lua_isnoneornil(lstate, 2)) {
     const char *flags = luaL_checkstring(lstate, 2);
     while (*flags) {

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -478,10 +478,18 @@ static int regexp_index(lua_State *lstate)
     const char *key = lua_tostring(lstate, 2);
     if (streq(key, "last_index")) {
       lua_pushnumber(lstate, r->last_index + 1);
+    } else if (streq(key, "dot_all")) {
+      lua_pushboolean(lstate, lre_get_flags(r->bc) & LRE_FLAG_DOTALL);
     } else if (streq(key, "global")) {
       lua_pushboolean(lstate, lre_get_flags(r->bc) & LRE_FLAG_GLOBAL);
+    } else if (streq(key, "ignore_case")) {
+      lua_pushboolean(lstate, lre_get_flags(r->bc) & LRE_FLAG_IGNORECASE);
+    } else if (streq(key, "multiline")) {
+      lua_pushboolean(lstate, lre_get_flags(r->bc) & LRE_FLAG_MULTILINE);
     } else if (streq(key, "sticky")) {
       lua_pushboolean(lstate, lre_get_flags(r->bc) & LRE_FLAG_STICKY);
+    } else if (streq(key, "unicode")) {
+      lua_pushboolean(lstate, lre_get_flags(r->bc) & LRE_FLAG_UTF16);
     } else if (streq(key, "source")) {
       lua_pushstring(lstate, r->expr);
     } else if (streq(key, "flags")) {

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -553,15 +553,11 @@ static int jsregexp_compile(lua_State *lstate)
         case 'm': re_flags |= LRE_FLAG_MULTILINE; break;
         case 'n': re_flags |= LRE_FLAG_NAMED_GROUPS; break;
         case 's': re_flags |= LRE_FLAG_DOTALL; break;
+        case 'u': re_flags |= LRE_FLAG_UTF16; break; 
         case 'y': re_flags |= LRE_FLAG_STICKY; break;
         default: /* unknown flag */;
       }
     }
-  }
-
-  if (utf8_contains_non_bmp(regexp)) {
-    // bmp range works fine without utf16 flag
-    re_flags |= LRE_FLAG_UTF16;
   }
 
   uint8_t *bc = lre_compile(&len, error_msg, sizeof error_msg, regexp,

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -498,6 +498,8 @@ static int regexp_index(lua_State *lstate)
       lua_pushnumber(lstate, r->last_index + 1);
     } else if (streq(key, "global")) {
       lua_pushboolean(lstate, lre_get_flags(r->bc) & LRE_FLAG_GLOBAL);
+    } else if (streq(key, "source")) {
+      lua_pushstring(lstate, r->expr);
     } else {
       return 0;
     }

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -327,7 +327,7 @@ static void regexp_pushflags(lua_State* lstate, const struct regexp *r) {
 static int regexp_tostring(lua_State *lstate)
 {
   const struct regexp *r = luaL_checkudata(lstate, 1, JSREGEXP_MT);
-  lua_pushfstring(lstate, "jsregexp: /%s/", r->expr);
+  lua_pushfstring(lstate, "/%s/", r->expr);
   regexp_pushflags(lstate, r);
   lua_concat(lstate, 2);
   return 1;

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -113,7 +113,6 @@ static inline uint16_t *utf8_to_utf16(
 }
 
 
-
 static int jsstring_new(lua_State* lstate) {
   size_t input_len;
   const uint8_t* input = (uint8_t*)luaL_checklstring(lstate, 1, &input_len);
@@ -155,8 +154,6 @@ static int jsstring_gc(lua_State* lstate) {
   }
   return 0;
 }
-
-
 
 static struct luaL_Reg jsstring_meta[] = {
   {"__gc", jsstring_gc},
@@ -319,9 +316,12 @@ static void regexp_pushflags(lua_State* lstate, const struct regexp *r) {
   const int flags = lre_get_flags(r->bc);
   const char* ignorecase = (flags & LRE_FLAG_IGNORECASE) ? "i" : "";
   const char* global = (flags & LRE_FLAG_GLOBAL) ? "g" : "";
+  const char* multiline = (flags & LRE_FLAG_MULTILINE) ? "m" : "";
   const char* named_groups = (flags & LRE_FLAG_NAMED_GROUPS) ? "n" : "";
+  const char* dotall = (flags & LRE_FLAG_DOTALL) ? "s" : "";
   const char* utf16 = (flags & LRE_FLAG_UTF16) ? "u" : "";
-  lua_pushfstring(lstate, "%s%s%s%s", ignorecase, global, named_groups, utf16);
+  const char* sticky = (flags & LRE_FLAG_STICKY) ? "y" : "";
+  lua_pushfstring(lstate, "%s%s%s%s%s%s%s", ignorecase, global, multiline, named_groups, dotall, utf16, sticky);
 }
 
 static int regexp_tostring(lua_State *lstate)
@@ -562,7 +562,10 @@ static int jsregexp_compile(lua_State *lstate)
       switch (*(flags++)) {
         case 'i': re_flags |= LRE_FLAG_IGNORECASE; break;
         case 'g': re_flags |= LRE_FLAG_GLOBAL; break;
+        case 'm': re_flags |= LRE_FLAG_MULTILINE; break;
         case 'n': re_flags |= LRE_FLAG_NAMED_GROUPS; break;
+        case 's': re_flags |= LRE_FLAG_DOTALL; break;
+        case 'y': re_flags |= LRE_FLAG_STICKY; break;
         default: /* unknown flag */;
       }
     }

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -409,16 +409,6 @@ static int regexp_exec(lua_State *lstate)
   }
   lua_setfield(lstate, -2, "index");
 
-  if (input->is_wide_char) {
-    const uint32_t a = input->indices[(capture[0] - input->u.str8) / 2];
-    const uint32_t b = input->indices[(capture[1] - input->u.str8) / 2];
-    lua_pushlstring(lstate, input->bstr+a, b-a);
-  } else {
-    lua_pushlstring(lstate, (char *) capture[0], capture[1] - capture[0]);
-  }
-  
-  lua_rawseti(lstate, -2, 0);
-
   if (group_names) {
     lua_newtable(lstate);               // match.groups
     lua_pushvalue(lstate, -1);
@@ -426,7 +416,7 @@ static int regexp_exec(lua_State *lstate)
     lua_insert(lstate, -2);             // leave table below the match table
   }
 
-  for (int i = 1; i < capture_count; i++) {
+  for (int i = 0; i < capture_count; i++) {
     if (input->is_wide_char) {
       const uint32_t a = input->indices[(capture[2*i] - input->u.str8) / 2];
       const uint32_t b = input->indices[(capture[2*i+1] - input->u.str8) / 2];
@@ -434,7 +424,7 @@ static int regexp_exec(lua_State *lstate)
     } else {
       lua_pushlstring(lstate, (char *) capture[2*i], capture[2*i+1] - capture[2*i]);
     }
-    if (group_names) {
+    if (i > 0 && group_names) {
       // if the current group is named, duplicate and insert into the correct
       // table
       if (*group_names) {

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -391,11 +391,16 @@ static int regexp_exec(lua_State *lstate)
   }
 
   lua_createtable(lstate, capture_count + 1, capture_count + 3);
+
   luaL_getmetatable(lstate, JSREGEXP_MATCH_MT);
   lua_setmetatable(lstate, -2);
 
   lua_pushstring(lstate, input->bstr);
   lua_setfield(lstate, -2, "input");
+
+  lua_pushinteger(lstate, capture_count);
+  lua_setfield(lstate, -2, "capture_count");
+
 
   if (input->is_wide_char) {
     lua_pushnumber(lstate, 1 + input->indices[(capture[0] - input->u.str8) / 2]); // 1-based

--- a/jsregexp.c
+++ b/jsregexp.c
@@ -454,6 +454,9 @@ static int regexp_exec(lua_State *lstate)
 
 static int regexp_test(lua_State *lstate)
 {
+  if (lua_gettop(lstate) != 2) {
+    return luaL_error(lstate, "expecting exactly 2 arguments");
+  }
   lua_pushcfunction(lstate, regexp_exec);
   lua_insert(lstate, 1);
   lua_call(lstate, 2, 1);

--- a/jsregexp.lua
+++ b/jsregexp.lua
@@ -1,12 +1,18 @@
-local jsregexp = require "jsregexp"
+local core = require "jsregexp.core"
 
-local lre = {}
+local jsregexp = {}
 
-function lre.match(re, str)
+jsregexp.to_jsstring = core.to_jsstring
+jsregexp.compile = core.compile
+jsregexp.compile_safe = core.compile_safe
+
+function core.mt.match(re, str)
     local jstr = jsregexp.to_jsstring(str)
     if not re.global then return re:exec(jstr) end
     local matches = {}
     local val
+
+    re.last_index = 1
 
     while true do
         val = re:exec(jstr)
@@ -16,20 +22,20 @@ function lre.match(re, str)
     return matches
 end
 
-function lre.match_all(re, str)
+function core.mt.match_all(re, str)
     -- must duplicate (according to string.proptype.matchAll spec)
     local re2 = jsregexp.compile(re.source, re.flags .. "g")
     local jstr = jsregexp.to_jsstring(str)
     return function() return re2:exec(jstr) end
 end
 
-function lre.match_all_list(re, str)
+function core.mt.match_all_list(re, str)
     local matches = {}
-    for match in lre.match_all(re, str) do table.insert(matches, match) end
+    for match in jsregexp.match_all(re, str) do table.insert(matches, match) end
     return matches
 end
 
-function lre.search(re, str)
+function core.mt.search(re, str)
     -- spec says to start at 1 and restore last_index
     local prev_last_index = re.last_index
     re.last_index = 1
@@ -39,7 +45,7 @@ function lre.search(re, str)
     return match.index
 end
 
-function lre.split(re, str, limit)
+function core.mt.split(re, str, limit)
     if limit == nil then limit = math.huge end
     if limit == 0 then return {} end
     assert(limit >= 0, "limit must be greater than 0")
@@ -130,7 +136,7 @@ local function get_substitution(match, str, replacement)
     return table.concat(result)
 end
 
-function lre.replace(re, str, replacement)
+function core.mt.replace(re, str, replacement)
 
     local jstr = jsregexp.to_jsstring(str)
 
@@ -157,4 +163,4 @@ function lre.replace(re, str, replacement)
     return table.concat(output)
 end
 
-return lre
+return jsregexp

--- a/jsregexp.lua
+++ b/jsregexp.lua
@@ -22,7 +22,7 @@ end
 
 function jsregexp.mt.match_all(re, str)
     -- must duplicate (according to string.proptype.matchAll spec)
-    local re2 = jsregexp.compile(re.source, re.flags .. "g")
+    local re2 = jsregexp.compile(re.source, re.flags)
     local jstr = jsregexp.to_jsstring(str)
     return function() return re2:exec(jstr) end
 end

--- a/jsregexp.lua
+++ b/jsregexp.lua
@@ -16,7 +16,9 @@ function jsregexp.mt.match(re, str)
         val = re:exec(jstr)
         if val == nil then break end
         table.insert(matches, val[0])
+        if #val[0] == 0 then re.last_index = re.last_index + 1 end
     end
+    if #matches == 0 then return nil end
     return matches
 end
 

--- a/jsregexp.lua
+++ b/jsregexp.lua
@@ -1,16 +1,10 @@
-local core = require "jsregexp.core"
-
-local jsregexp = {}
+local jsregexp = require "jsregexp.core"
 
 setmetatable(jsregexp, {
     __call = function(self, expr, flags) return jsregexp.compile(expr, flags) end
 })
 
-jsregexp.to_jsstring = core.to_jsstring
-jsregexp.compile = core.compile
-jsregexp.compile_safe = core.compile_safe
-
-function core.mt.match(re, str)
+function jsregexp.mt.match(re, str)
     local jstr = jsregexp.to_jsstring(str)
     if not re.global then return re:exec(jstr) end
     local matches = {}
@@ -26,20 +20,20 @@ function core.mt.match(re, str)
     return matches
 end
 
-function core.mt.match_all(re, str)
+function jsregexp.mt.match_all(re, str)
     -- must duplicate (according to string.proptype.matchAll spec)
     local re2 = jsregexp.compile(re.source, re.flags .. "g")
     local jstr = jsregexp.to_jsstring(str)
     return function() return re2:exec(jstr) end
 end
 
-function core.mt.match_all_list(re, str)
+function jsregexp.mt.match_all_list(re, str)
     local matches = {}
     for match in jsregexp.match_all(re, str) do table.insert(matches, match) end
     return matches
 end
 
-function core.mt.search(re, str)
+function jsregexp.mt.search(re, str)
     -- spec says to start at 1 and restore last_index
     local prev_last_index = re.last_index
     re.last_index = 1
@@ -49,7 +43,7 @@ function core.mt.search(re, str)
     return match.index
 end
 
-function core.mt.split(re, str, limit)
+function jsregexp.mt.split(re, str, limit)
     if limit == nil then limit = math.huge end
     if limit == 0 then return {} end
     assert(limit >= 0, "limit must be greater than 0")
@@ -140,7 +134,7 @@ local function get_substitution(match, str, replacement)
     return table.concat(result)
 end
 
-function core.mt.replace(re, str, replacement)
+function jsregexp.mt.replace(re, str, replacement)
 
     local jstr = jsregexp.to_jsstring(str)
 

--- a/jsregexp.lua
+++ b/jsregexp.lua
@@ -2,6 +2,10 @@ local core = require "jsregexp.core"
 
 local jsregexp = {}
 
+setmetatable(jsregexp, {
+    __call = function(self, expr, flags) return jsregexp.compile(expr, flags) end
+})
+
 jsregexp.to_jsstring = core.to_jsstring
 jsregexp.compile = core.compile
 jsregexp.compile_safe = core.compile_safe

--- a/lre.lua
+++ b/lre.lua
@@ -82,4 +82,9 @@ function lre.replace(re, str, replacement)
     return table.concat(newstr)
 end
 
+function lre.replace_all(re, str, replacement)
+    local re2 = jsregexp.compile(re.source, re.flags .. "g")
+    return lre.replace(re2, str, replacement) -- add global if user forgot
+end
+
 return lre

--- a/lre.lua
+++ b/lre.lua
@@ -1,0 +1,85 @@
+local jsregexp = require "jsregexp"
+
+local lre = {}
+
+function lre.match(re, str)
+    local jstr = jsregexp.to_jsstring(str)
+    if not re.global then return re:exec(jstr) end
+    local matches = {}
+    local val
+
+    while true do
+        val = re:exec(jstr)
+        if val == nil then break end
+        table.insert(matches, val[0])
+    end
+    return matches
+end
+
+function lre.match_all(re, str)
+    -- must duplicate (according to string.proptype.matchAll spec)
+    local re2 = jsregexp.compile(re.source, re.flags .. "g")
+    local jstr = jsregexp.to_jsstring(str)
+    return function() return re2:exec(jstr) end
+end
+
+function lre.match_all_list(re, str)
+    local matches = {}
+    for match in lre.match_all(re, str) do table.insert(matches, match) end
+    return matches
+end
+
+function lre.search(re, str)
+    -- spec says to start at 1 and restore last_index
+    local prev_last_index = re.last_index
+    re.last_index = 1
+    local match = re:exec(str)
+    re.last_index = prev_last_index
+    if match == nil then return -1 end
+    return match.index
+end
+
+function lre.split(re, str, limit)
+    if limit == nil then limit = math.huge end
+    if limit == 0 then return {} end
+    assert(limit >= 0, "limit must be greater than 0")
+
+    local jstr = re.to_jsstring(str)
+    local re2 = jsregexp.compile(re.source, re.flags .. "y") -- add sticky
+
+    local count = 0
+    local split = {}
+    while count < limit do
+        local prev_index = re2.last_index
+        local match = re2:exec(jstr)
+        if match == nil then break end
+        local element = string.sub(str, prev_index + 1, match.index - 1)
+        if #element > 0 or #match[0] then table.insert(split, element) end
+    end
+    return split
+end
+
+function lre.replace(re, str, replacement)
+
+    local jstr = jsregexp.to_jsstring(str)
+
+    local newstr = {}
+
+    while true do
+        local prev_index = re.last_index
+        local match = re:exec(jstr)
+        if match == nil then break end
+        local repl
+        if type(replacement) == "function" then
+            repl = replacement(match)
+        else
+            -- todo
+            repl = replacement
+        end
+        table.insert(newstr, string.sub(str, prev_index + 1, match.index - 1))
+        table.insert(newstr, repl)
+    end
+    return table.concat(newstr)
+end
+
+return lre


### PR DESCRIPTION
Starting to implement the functionality. This should 

- add utf8 support to `test` and `exec`. It also applies it to `__call`
- new function `to_jsstring` and datatype `jsstring` to store utf16 version when needed
- remaining missing flags